### PR TITLE
[Feat] Add TTL Support to Cache

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -5,52 +5,44 @@ import (
 	"time"
 )
 
-func TestCache(t *testing.T) {
-	defaultDuration := time.Second * 2
-	cache := NewCache(defaultDuration)
-
-	// Test Set and Get
-	cache.Set("key1", "value1")
-	value, found := cache.Get("key1")
-	if !found || value != "value1" {
-		t.Errorf("Expected 'value1', found '%v'", value)
+func TestCache_SetAndGet(t *testing.T) {
+	testCases := []struct {
+		name     string
+		duration time.Duration
+	}{
+		{"DefaultDuration", 10 * time.Second},
+		{"CustomDuration", 5 * time.Second},
 	}
 
-	// Test expiration
-	time.Sleep(defaultDuration + time.Millisecond*500) // Wait for item to expire
-	value, found = cache.Get("key1")
-	if found || value != nil {
-		t.Errorf("Expected cache miss, found '%v'", value)
-	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := NewCache(tc.duration)
 
-	// Test custom duration
-	cache.Set("key2", "value2", time.Second*3)
-	value, found = cache.Get("key2")
-	if !found || value != "value2" {
-		t.Errorf("Expected 'value2', found '%v'", value)
-	}
+			cache.Set("key1", "value1")
+			cache.Set("key2", "value2", 5*time.Second)
 
-	// Test cache eviction due to expiration
-	time.Sleep(time.Second * 3) // Wait for item to expire
-	value, found = cache.Get("key2")
-	if found || value != nil {
-		t.Errorf("Expected cache miss, found '%v'", value)
-	}
-}
+			value1, exists1 := cache.Get("key1")
+			if !exists1 || value1 != "value1" {
+				t.Errorf("Expected 'value1' to exist in cache with key 'key1', but got value: %v", value1)
+			}
 
-func TestCacheWithDefaultDuration(t *testing.T) {
-	defaultDuration := time.Second * 2
-	cache := NewCache(defaultDuration)
+			value2, exists2 := cache.Get("key2")
+			if !exists2 || value2 != "value2" {
+				t.Errorf("Expected 'value2' to exist in cache with key 'key2', but got value: %v", value2)
+			}
 
-	cache.Set("key1", "value1")
-	value, found := cache.Get("key1")
-	if !found || value != "value1" {
-		t.Errorf("Expected 'value1', found '%v'", value)
-	}
+			value3, exists3 := cache.Get("nonexistent_key")
+			if exists3 || value3 != nil {
+				t.Errorf("Expected 'nonexistent_key' to not exist in cache, but got value: %v", value3)
+			}
 
-	time.Sleep(defaultDuration + time.Millisecond*500) // Wait for item to expire
-	value, found = cache.Get("key1")
-	if found || value != nil {
-		t.Errorf("Expected cache miss, found '%v'", value)
+			// Wait for the shorter cache entry to expire
+			time.Sleep(6 * time.Second)
+
+			value2AfterExpiry, exists2AfterExpiry := cache.Get("key2")
+			if exists2AfterExpiry || value2AfterExpiry != nil {
+				t.Errorf("Expected 'key2' to have expired and not exist in cache, but got value: %v", value2AfterExpiry)
+			}
+		})
 	}
 }

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,56 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCache(t *testing.T) {
+	defaultDuration := time.Second * 2
+	cache := NewCache(defaultDuration)
+
+	// Test Set and Get
+	cache.Set("key1", "value1")
+	value, found := cache.Get("key1")
+	if !found || value != "value1" {
+		t.Errorf("Expected 'value1', found '%v'", value)
+	}
+
+	// Test expiration
+	time.Sleep(defaultDuration + time.Millisecond*500) // Wait for item to expire
+	value, found = cache.Get("key1")
+	if found || value != nil {
+		t.Errorf("Expected cache miss, found '%v'", value)
+	}
+
+	// Test custom duration
+	cache.Set("key2", "value2", time.Second*3)
+	value, found = cache.Get("key2")
+	if !found || value != "value2" {
+		t.Errorf("Expected 'value2', found '%v'", value)
+	}
+
+	// Test cache eviction due to expiration
+	time.Sleep(time.Second * 3) // Wait for item to expire
+	value, found = cache.Get("key2")
+	if found || value != nil {
+		t.Errorf("Expected cache miss, found '%v'", value)
+	}
+}
+
+func TestCacheWithDefaultDuration(t *testing.T) {
+	defaultDuration := time.Second * 2
+	cache := NewCache(defaultDuration)
+
+	cache.Set("key1", "value1")
+	value, found := cache.Get("key1")
+	if !found || value != "value1" {
+		t.Errorf("Expected 'value1', found '%v'", value)
+	}
+
+	time.Sleep(defaultDuration + time.Millisecond*500) // Wait for item to expire
+	value, found = cache.Get("key1")
+	if found || value != nil {
+		t.Errorf("Expected cache miss, found '%v'", value)
+	}
+}


### PR DESCRIPTION
- Introduced a new `cacheItem` struct to hold cached values along with their expiry times.
- Modified the `Set` function to accept an additional parameter for specifying the TTL duration of cached items.
