### PR TITLE
refactor: replace log with slog

### DIFF
--- a/cmd/core/core.go
+++ b/cmd/core/core.go
@@ -4,7 +4,6 @@ import (
 	"bepass/bufferpool"
 	"bepass/dialer"
 	"bepass/doh"
-	"bepass/logger"
 	"bepass/resolve"
 	"bepass/server"
 	"bepass/socks5"
@@ -13,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/signal"
 	"strings"
@@ -56,16 +54,11 @@ func RunServer(config *Config, captureCTRLC bool) error {
 	var resolveSystem string
 	var dohClient *doh.Client
 
-	stdLogger := log.New(os.Stderr, "", log.Ldate|log.Ltime)
-	appLogger := logger.NewLogger(stdLogger)
-
 	localResolver := &resolve.LocalResolver{
-		Logger: appLogger,
-		Hosts:  config.Hosts,
+		Hosts: config.Hosts,
 	}
 
 	dialer_ := &dialer.Dialer{
-		Logger:                appLogger,
 		EnableLowLevelSockets: config.EnableLowLevelSockets,
 		TLSPaddingEnabled:     config.TLSPaddingEnabled,
 		TLSPaddingSize:        config.TLSPaddingSize,
@@ -75,7 +68,6 @@ func RunServer(config *Config, captureCTRLC bool) error {
 	wsTunnel := &transport.WSTunnel{
 		BindAddress:        config.BindAddress,
 		Dialer:             dialer_,
-		Logger:             appLogger,
 		ReadTimeout:        config.UDPReadTimeout,
 		WriteTimeout:       config.UDPWriteTimeout,
 		LinkIdleTimeout:    config.UDPLinkIdleTimeout,
@@ -86,7 +78,6 @@ func RunServer(config *Config, captureCTRLC bool) error {
 	transport_ := &transport.Transport{
 		WorkerAddress: config.WorkerAddress,
 		BindAddress:   config.BindAddress,
-		Logger:        appLogger,
 		Dialer:        dialer_,
 		BufferPool:    bufferpool.NewPool(32 * 1024),
 		UDPBind:       config.UDPBindAddress,
@@ -123,7 +114,6 @@ func RunServer(config *Config, captureCTRLC bool) error {
 		Cache:                 appCache,
 		ResolveSystem:         resolveSystem,
 		DoHClient:             dohClient,
-		Logger:                appLogger,
 		ChunkConfig:           chunkConfig,
 		WorkerConfig:          workerConfig,
 		BindAddress:           config.BindAddress,

--- a/dialer/dialer.go
+++ b/dialer/dialer.go
@@ -1,14 +1,12 @@
 package dialer
 
 import (
-	"bepass/logger"
 	"net"
 )
 
 type PlainTCPDial func(network, addr, hostPort string) (net.Conn, error)
 
 type Dialer struct {
-	Logger                *logger.Std
 	EnableLowLevelSockets bool
 	TLSPaddingEnabled     bool
 	TLSPaddingSize        [2]int

--- a/dialer/tcp.go
+++ b/dialer/tcp.go
@@ -1,6 +1,7 @@
 package dialer
 
 import (
+	"bepass/logger"
 	"bepass/protect"
 	"net"
 	"runtime"
@@ -31,7 +32,7 @@ func (d *Dialer) TCPDial(network, addr, hostPort string) (*net.TCPConn, error) {
 	}
 	conn, err := net.DialTCP("tcp", nil, tcpAddr)
 	if err != nil {
-		d.Logger.Errorf("failed to connect to %v: %v", tcpAddr, err)
+		logger.Errorf("failed to connect to %v: %v", tcpAddr, err)
 		return nil, err
 	}
 	return conn, nil

--- a/resolve/local.go
+++ b/resolve/local.go
@@ -1,7 +1,6 @@
 package resolve
 
 import (
-	"bepass/logger"
 	"net"
 )
 
@@ -11,8 +10,7 @@ type Hosts struct {
 }
 
 type LocalResolver struct {
-	Logger *logger.Std
-	Hosts  []Hosts
+	Hosts []Hosts
 }
 
 func (lr *LocalResolver) Resolve(domain string) string {

--- a/socks5/handle.go
+++ b/socks5/handle.go
@@ -1,14 +1,12 @@
 package socks5
 
 import (
+	"bepass/logger"
 	"bepass/socks5/statute"
+	"context"
 	"fmt"
 	"io"
 	"net"
-)
-
-import (
-	"context"
 	"strings"
 	"sync"
 )
@@ -217,7 +215,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 	}
 	//defer bindLn.Close()
 
-	sf.logger.Info("target addr ", target.RemoteAddr(), " listen addr: ", bindLn.LocalAddr())
+	logger.Info("", "target addr ", target.RemoteAddr(), " listen addr: ", bindLn.LocalAddr())
 	// send BND.ADDR and BND.PORT, client used
 	if err = SendReply(writer, statute.RepSuccess, bindLn.LocalAddr()); err != nil {
 		return fmt.Errorf("failed to send reply, %v", err)
@@ -239,7 +237,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 					return
 				}
 				if strings.Contains(err.Error(), "use of closed network connection") {
-					sf.logger.Errorf("read data from bind listen address %s failed, %v", bindLn.LocalAddr(), err)
+					logger.Errorf("read data from bind listen address %s failed, %v", bindLn.LocalAddr(), err)
 					return
 				}
 				continue
@@ -267,7 +265,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 							if err == io.EOF {
 								return
 							}
-							sf.logger.Errorf("read data from remote %s failed, %v", target.RemoteAddr().String(), err)
+							logger.Errorf("read data from remote %s failed, %v", target.RemoteAddr().String(), err)
 							return
 						}
 
@@ -281,7 +279,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 						proBuf = append(proBuf, pkb.Data...)
 						if _, err := bindLn.WriteTo(proBuf, srcAddr); err != nil {
 							sf.bufferPool.Put(tmpBufPool)
-							sf.logger.Errorf("write data to client %s failed, %v", bindLn.LocalAddr(), err)
+							logger.Errorf("write data to client %s failed, %v", bindLn.LocalAddr(), err)
 							return
 						}
 						sf.bufferPool.Put(tmpBufPool)
@@ -290,7 +288,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 			}
 
 			if _, err := target.Write(pk.Data); err != nil {
-				sf.logger.Errorf("write data to remote %s failed, %v", target.RemoteAddr().String(), err)
+				logger.Errorf("write data to remote %s failed, %v", target.RemoteAddr().String(), err)
 				return
 			}
 		}
@@ -301,7 +299,7 @@ func (sf *Server) handleAssociate(ctx context.Context, writer io.Writer, request
 
 	for {
 		num, err := request.Reader.Read(buf[:cap(buf)])
-		sf.logger.Errorf("read data from client %s, %d bytesm, err is %+v", request.RemoteAddr.String(), num, err)
+		logger.Errorf("read data from client %s, %d bytesm, err is %+v", request.RemoteAddr.String(), num, err)
 		if err != nil {
 			if err == io.EOF {
 				return nil

--- a/socks5/option.go
+++ b/socks5/option.go
@@ -2,7 +2,6 @@ package socks5
 
 import (
 	"bepass/bufferpool"
-	"bepass/logger"
 	"context"
 	"io"
 	"net"
@@ -74,11 +73,11 @@ func WithBindIP(ip net.IP) Option {
 
 // WithLogger can be used to provide a custom log target.
 // Defaults to io.Discard.
-func WithLogger(l logger.Logger) Option {
-	return func(s *Server) {
-		s.logger = l
-	}
-}
+// func WithLogger(l logger.Logger) Option {
+// 	return func(s *Server) {
+// 		s.logger = l
+// 	}
+// }
 
 // WithDial Optional function for dialing out
 func WithDial(dial func(ctx context.Context, network, addr string) (net.Conn, error)) Option {

--- a/socks5/server.go
+++ b/socks5/server.go
@@ -6,15 +6,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/net/proxy"
 	"io"
-	"log"
 	"net"
 	"net/http"
-	"os"
+
+	"golang.org/x/net/proxy"
 
 	"bepass/logger"
 	"bepass/socks5/statute"
+
 	"github.com/elazarl/goproxy"
 )
 
@@ -46,9 +46,6 @@ type Server struct {
 	rewriter AddressRewriter
 	// bindIP is used for bind or udp associate
 	bindIP net.IP
-	// logger can be used to provide a custom log target.
-	// Defaults to io.Discard.
-	logger logger.Logger
 	// Optional function for dialing out
 	dial func(ctx context.Context, network, addr string) (net.Conn, error)
 	// buffer pool
@@ -66,14 +63,11 @@ type Server struct {
 
 // NewServer creates a new Server
 func NewServer(opts ...Option) *Server {
-	stdLogger := log.New(os.Stderr, "socksLogger", log.Ldate|log.Ltime)
-	socksLogger := logger.NewLogger(stdLogger)
 	srv := &Server{
 		authMethods: []Authenticator{},
 		bufferPool:  bufferpool.NewPool(32 * 1024),
 		resolver:    DNSResolver{},
 		rules:       NewPermitAll(),
-		logger:      socksLogger,
 		dial: func(ctx context.Context, net_, addr string) (net.Conn, error) {
 			return net.Dial(net_, addr)
 		},
@@ -145,16 +139,16 @@ func (sf *Server) Serve() error {
 		if err != nil {
 			select {
 			case <-sf.done:
-				sf.logger.Info("Shutting socks5 server done")
+				logger.Info("Shutting socks5 server done")
 				return nil
 			default:
-				sf.logger.Errorf("Accept failed: %v", err)
+				logger.Errorf("Accept failed: %v", err)
 				return err
 			}
 		}
 		sf.goFunc(func() {
 			if err := sf.ServeConn(conn); err != nil {
-				sf.logger.Errorf("server: %v", err)
+				logger.Errorf("server: %v", err)
 			}
 		})
 	}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -34,7 +34,6 @@ type UDPConf struct {
 type Transport struct {
 	WorkerAddress string
 	BindAddress   string
-	Logger        *logger.Std
 	Dialer        *dialer.Dialer
 	BufferPool    bufferpool.BufPool
 	UDPBind       string
@@ -52,7 +51,7 @@ func (t *Transport) Handle(network string, w io.Writer, req *socks5.Request) err
 		return t.TunnelUDP(w, req)
 	}
 	if err := socks5.SendReply(w, statute.RepSuccess, nil); err != nil {
-		t.Logger.Errorf("failed to send reply: %v", err)
+		logger.Errorf("failed to send reply: %v", err)
 		return err
 	}
 
@@ -61,7 +60,7 @@ func (t *Transport) Handle(network string, w io.Writer, req *socks5.Request) err
 		if err := socks5.SendReply(w, statute.RepServerFailure, nil); err != nil {
 			return err
 		}
-		t.Logger.Printf("Could not split host and port: %v\n", err)
+		logger.Infof("Could not split host and port: %v\n", err)
 		return err
 	}
 
@@ -70,7 +69,7 @@ func (t *Transport) Handle(network string, w io.Writer, req *socks5.Request) err
 		if err := socks5.SendReply(w, statute.RepServerFailure, nil); err != nil {
 			return err
 		}
-		t.Logger.Printf("Can not connect: %v\n", err)
+		logger.Infof("Can not connect: %v\n", err)
 		return err
 	}
 
@@ -119,7 +118,7 @@ func (t *Transport) TunnelUDP(w io.Writer, req *socks5.Request) error {
 	}
 	fmt.Println(bindLn.LocalAddr())
 	if err := socks5.SendReply(w, statute.RepSuccess, bindLn.LocalAddr()); err != nil {
-		t.Logger.Errorf("failed to send reply: %v", err)
+		logger.Errorf("failed to send reply: %v", err)
 		return err
 	}
 
@@ -128,14 +127,14 @@ func (t *Transport) TunnelUDP(w io.Writer, req *socks5.Request) error {
 		if err := socks5.SendReply(w, statute.RepServerFailure, nil); err != nil {
 			return err
 		}
-		t.Logger.Printf("Could not split host and port: %v\n", err)
+		logger.Infof("Could not split host and port: %v\n", err)
 		return err
 	}
 
 	bindWriteChannel := make(chan UDPPacket)
 	tunnelWriteChannel, channelIndex, err := t.Tunnel.PersistentDial(tunnelEndpoint, bindWriteChannel)
 	if err != nil {
-		t.Logger.Errorf("Unable to get or create tunnel for udpBindWriteChannel %v\r\n", err)
+		logger.Errorf("Unable to get or create tunnel for udpBindWriteChannel %v\r\n", err)
 		return err
 	}
 	// make new Bind
@@ -157,7 +156,7 @@ func (t *Transport) TunnelUDP(w io.Writer, req *socks5.Request) error {
 					break
 				}
 				if strings.Contains(err.Error(), "use of closed network connection") {
-					t.Logger.Errorf("read data from bind listen address %s failed, %v", udpBind.AssociateBind.LocalAddr(), err)
+					logger.Errorf("read data from bind listen address %s failed, %v", udpBind.AssociateBind.LocalAddr(), err)
 				}
 				break
 			}


### PR DESCRIPTION
Passing the logger throughout the code is not a good idea and it turns your code into spaghetti code.

Now, Logger is a standalone package that works globally. You can use it like the slog package by importing it into any package.

And the new logger package is a wrapper around slog, and the exported functions are the same as before, so there are minimal code changes.

```
import "bepass/logger"

logger.Error(msg, args)
logger.Errorf(format, args)
```